### PR TITLE
MINOR: Repairing YAML syntax error on our-bots-yeebot

### DIFF
--- a/_posts/2022-07-14-our-bots-yeebot.md
+++ b/_posts/2022-07-14-our-bots-yeebot.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Yeebot: About/how-to
+title: Yeebot﹕About/how-to
 date: 2022-07-14 18:45
 author: yeahgamesdevs
 comments: true


### PR DESCRIPTION
Repaired YAML syntax error where a real colon ":" was used in the metadata and caused a range of errors

[minor]