### PR TITLE
Updating to include canonical refs

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -15,6 +15,11 @@ tail_includes:
   <meta http-equiv="refresh" content="0;URL='https://login.yeahgames.net/token/{{page.token}}'" />
 {% endif %}
 {% if page.link %}
+<link rel="canonical" href="{{page.link}}"/>
+{% endif %}
+{% if page.token %}
+<link rel="canonical" href="https://login.yeahgames.net/token/{{page.token}}"/>
+{% endif %}
   {% unless page.c == "Main" %}
   <meta http-equiv="refresh" content="0;URL='{{page.link}}'" />
   {% endunless %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -20,6 +20,9 @@ tail_includes:
 {% if page.token %}
 <link rel="canonical" href="https://login.yeahgames.net/token/{{page.token}}"/>
 {% endif %}
+{% if page.token %}
+<meta name="robots" content="noindex"/>
+{% endif %}
   {% unless page.c == "Main" %}
   <meta http-equiv="refresh" content="0;URL='{{page.link}}'" />
   {% endunless %}


### PR DESCRIPTION
For indexing and search purposes, items with a `link` or `token` attribute will automatically attach themselves with a canonical link to that link/token, so search engines only display the actual page canonically (the link/token).